### PR TITLE
Fix invisible chart text on dark reader theme

### DIFF
--- a/src/site/styles/custom-style.scss
+++ b/src/site/styles/custom-style.scss
@@ -10,4 +10,18 @@ body {
     //  h1 {
     //   color: black;
     //  }
+
+    /* Charts and figures clipped from other sites are frequently transparent
+       PNGs whose title/axis/legend text was authored dark for a light page.
+       On the dark reader theme the transparency lets the background show
+       through, so that text disappears (bars and white in-bar labels survive).
+       Give note-body images a white "figure card" background so they stay
+       legible. Opaque images (photos, screenshots) are unaffected because the
+       background sits behind their pixels. */
+    .markdown-rendered img {
+        background-color: #ffffff;
+        box-sizing: border-box;
+        padding: 0.6rem;
+        border-radius: 8px;
+    }
 }


### PR DESCRIPTION
## Problem

Charts in notes like *700 to 1 — The funding ratio undermining our future food system* render with their **title, country labels, legend, axis title, and data-source line invisible** on the site.

Root cause: these figures are clipped from external sites (e.g. claimingsteaks.com) as **transparent PNGs** whose text was authored in dark grey for a *light* page. RIAAK's dark reader theme shows through the transparency, so the dark text disappears — only the opaque bars and white in-bar labels survive.

## Fix

One rule in `custom-style.scss` (the designated override file, loaded last) gives note-body images a white "figure card" background:

```scss
.markdown-rendered img {
    background-color: #ffffff;
    box-sizing: border-box;
    padding: 0.6rem;
    border-radius: 8px;
}
```

- Transparent charts become fully legible.
- Opaque images (photos/screenshots) are unaffected — the white sits behind their pixels.
- Also covers any future transparent chart clipped into the vault, not just this note.

Compiles cleanly via `npm run build:sass`.

## Tradeoff

Any image *designed for a dark background* (light text on transparency) would now sit on white — the rare inverse case. The dark-text-on-light case fixed here is by far the common one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)